### PR TITLE
[ new ] Descriptions are closed under products

### DIFF
--- a/doc/common/Generic/Syntax/LetBinder.lagda
+++ b/doc/common/Generic/Syntax/LetBinder.lagda
@@ -11,7 +11,7 @@ open import Agda.Builtin.Equality
 open import Function
 open import Relation.Unary
 
-open import Generic.Syntax
+open import Generic.Syntax hiding (uncurry; curry)
 
 private
   variable

--- a/doc/common/Generic/Syntax/LetBinders.lagda
+++ b/doc/common/Generic/Syntax/LetBinders.lagda
@@ -10,7 +10,7 @@ open import Agda.Builtin.Equality
 open import Function
 open import Relation.Unary
 
-open import Generic.Syntax
+open import Generic.Syntax hiding (curry; uncurry)
 
 module _ {I : Set} where
 


### PR DESCRIPTION
As remarked by @anuyts (private communication), our descriptions
are actually closed under products. It's just a bit more annoying
to implement than closure under sums.